### PR TITLE
Изменить цвет текста в combobox на темной теме.

### DIFF
--- a/src/shared/ui/FormCombobox/ui/FormCombobox.tsx
+++ b/src/shared/ui/FormCombobox/ui/FormCombobox.tsx
@@ -5,13 +5,13 @@ import { cn } from "@/shared/lib/utils";
 import {
   Command,
   CommandEmpty,
-  CommandInput,
-  CommandList,
   CommandGroup,
+  CommandInput,
   CommandItem,
+  CommandList,
 } from "@/shared/ui/command";
 import React from "react";
-import { ControllerRenderProps, UseFormSetValue } from "react-hook-form";
+import { UseFormSetValue } from "react-hook-form";
 
 type FormComboboxParams = {
   value: string;
@@ -54,7 +54,7 @@ export const FormCombobox = ({
             <Button
               role="combobox"
               variant="ghost"
-              className={cn("text-white", !value && "text-muted-foreground")}
+              className={cn("text-black dark:text-white", !value && "text-muted-foreground")}
             >
               {value ? options.find((info) => info === value) : placeholder}
             </Button>


### PR DESCRIPTION
Цвет текста кнопки в combobox изменен на черный в светлой теме и белый в темной теме с помощью класса `text-black dark:text-white`. Это улучшает читаемость текста в зависимости от текущей темы.