### PR TITLE
Изменен URL для получения профиля

### DIFF
--- a/src/shared/services/ProfileService.ts
+++ b/src/shared/services/ProfileService.ts
@@ -27,7 +27,7 @@ class ProfileService {
   }
 
   async getProfile(body: TGetProfileRequest): Promise<TGetProfileResponse> {
-    const { data } = await $api.post<TGetProfileResponse>(`${this.BASE_URL}/info`, body);
+    const { data } = await $api.post<TGetProfileResponse>(`${this.BASE_URL}/details`, body);
 
     return data;
   }


### PR DESCRIPTION
Старый URL "/info" заменен на новый "/details" в методе getProfile. Это изменение было сделано для корректного взаимодействия с API и получения актуальных данных пользователя.