### PR TITLE
Добавлена поддержка передачи значения priority

### DIFF
--- a/src/entities/ProfileCard/ui/ProfileCard.tsx
+++ b/src/entities/ProfileCard/ui/ProfileCard.tsx
@@ -56,6 +56,7 @@ export const ProfileCard = ({ profile }: ProfileCardParams) => {
     formUpdate.append('enabled', profile?.isEnabled.toString());
     formUpdate.append('jvmArguments', profile?.jvmArguments);
     formUpdate.append('gameArguments', profile?.gameArguments);
+    formUpdate.append('priority', profile?.priority?.toString() ?? '0');
 
     if (body.icon && body.icon[0]) {
       formUpdate.append('icon', body.icon[0]);


### PR DESCRIPTION
В метод обновления формы добавлено новое поле `priority`. Это гарантирует возможность передачи приоритета профиля, даже если оно отсутствует в данных, задавая значение по умолчанию "0".